### PR TITLE
Fix the Function  parameter

### DIFF
--- a/12_python_mongodb/youtube_manager_mongodb.py
+++ b/12_python_mongodb/youtube_manager_mongodb.py
@@ -49,7 +49,7 @@ def main():
             update_video(video_id, name, time)
         elif choice == '4':
             video_id = input("Enter the video id to update: ")
-            delete_video(video_id, name, time)
+            delete_video(video_id)
         elif choice == '5':
             break
         else:


### PR DESCRIPTION
There’s an issue on line 52 where the delete_video(video_id, name, time) function is called with three arguments, but it only requires one (video_id).

P.S.: I also checked the comments to see if anyone had already resolved it, but didn’t find anything — so I’ve created a pull request. Hope that’s alright!